### PR TITLE
Use cross-platform linker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@ Example Rust project for building UEFI applications.
 
 ## Requirements
 
- - rustup
+ - rustup (nightly)
  - Xargo
- - `lld-link`
-   
-   Tested with LLD from LLVM 6 & 7.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Example Rust project for building UEFI applications.
 
 ## Requirements
 
- - rustup (nightly)
+ - rustup
  - Xargo
 
 ## Building

--- a/uefi-app-x64.json
+++ b/uefi-app-x64.json
@@ -6,8 +6,7 @@
 	"target-pointer-width": "64",
 	"target-c-int-width": "32",
 	"os": "none",
-	"linker-flavor": "msvc",
-	"linker": "lld-link",
+	"linker-flavor": "lld-link",
 	"executables": true,
 	"features": "-mmx,-sse,+soft-float",
 	"disable-redzone": true,
@@ -15,7 +14,7 @@
 	"no-default-libraries": true,
 
 	"pre-link-args": {
-		"msvc": [
+		"lld-link": [
 			"/NOLOGO",
 			"/NXCOMPAT",
 			"/SUBSYSTEM:EFI_APPLICATION",


### PR DESCRIPTION
Rust toolchain has included a built-in cross-platform linker since the 2018-03-05 nightly as described in [here](https://os.phil-opp.com/minimal-rust-kernel/), so you can use it.

I tested with the 2018-03-06 nightly toolchain and QEMU 2.11.1 on macOS 10.13.3.